### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/docs/modules/preview/index.ts
+++ b/docs/modules/preview/index.ts
@@ -20,6 +20,7 @@ export default defineNuxtModule({
     const { resolve } = createResolver(import.meta.url)
 
     nuxt.hook('builder:watch', (event, filename) => {
+      filename = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, filename))
       if (!filename.endsWith('.md')) {
         return
       }


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

