### PR TITLE
fix(docs): resolve oniguruma-to-es build error in nuxt generate

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -20,5 +20,10 @@ export default defineNuxtConfig({
     define: {
       __WEB__: 'true',
     },
+    resolve: {
+      alias: {
+        'oniguruma-to-es': 'oniguruma-to-es/dist/index.mjs',
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- 修复 `nuxt generate` 构建报错：`"toRegExp" is not exported by oniguruma-to-es/dist/index.min.js`
- 根因：`oniguruma-to-es@0.7.0` 的 `index.min.js` 是 IIFE 格式，没有 ES module named exports；Rollup SSR 构建时错误解析到 `.min.js` 而不是 `.mjs`
- 修复方式：在 `nuxt.config.ts` 中添加 Vite resolve alias，强制解析到正确的 ESM 入口文件

## Test plan
- [ ] 本地 `pnpm -F docs run generate` 构建成功
- [ ] CI 构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)