### PR TITLE
fix(docs): use absolute path for oniguruma-to-es alias

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url'
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   modules: ['@nuxt/content', '@unocss/nuxt', '@nuxt/image'],
@@ -22,7 +24,7 @@ export default defineNuxtConfig({
     },
     resolve: {
       alias: {
-        'oniguruma-to-es': 'oniguruma-to-es/dist/index.mjs',
+        'oniguruma-to-es': fileURLToPath(new URL('../node_modules/oniguruma-to-es/dist/index.mjs', import.meta.url)),
       },
     },
   },


### PR DESCRIPTION
## Summary
- Fix `pnpm run build` failure in docs caused by Vite exports field validation
- Previous fix (#243) used a package-relative path (`oniguruma-to-es/dist/index.mjs`) as alias value, but Vite still resolves it through the `exports` field — which only declares `.`, not `./dist/index.mjs`
- Changed to absolute file path via `fileURLToPath(new URL(...))` to bypass exports validation entirely

## Test plan
- [x] `pnpm run build` in docs/ passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>