### PR TITLE
fix(docs): correct Nuxt content path and remove redundant redirect

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -4,9 +4,6 @@ import { fileURLToPath } from 'node:url'
 export default defineNuxtConfig({
   modules: ['@nuxt/content', '@unocss/nuxt', '@nuxt/image'],
   devtools: { enabled: true },
-  routeRules: {
-    '/': { redirect: '/get-started/introduction' },
-  },
   app: {
     head: {
       titleTemplate: '%s - Dango UI',

--- a/docs/pages/[...slug].vue
+++ b/docs/pages/[...slug].vue
@@ -1,6 +1,6 @@
 <template>
   <article class="doc-article">
-    <ContentDoc class="doc-prose prose" />
+    <ContentDoc class="doc-prose prose" :path="contentPath" />
 
     <nav class="doc-nav-footer">
       <NuxtLink


### PR DESCRIPTION
## Summary
- Remove redundant `routeRules` redirect (`/ → /get-started/introduction`) from `nuxt.config.ts` — this was causing path resolution issues
- Pass explicit `:path="contentPath"` to `<ContentDoc>` in `[...slug].vue` to fix content rendering with correct paths

## Test plan
- [ ] Verify docs site loads correctly at root `/`
- [ ] Verify content pages render properly (e.g. `/get-started/introduction`)
- [ ] Confirm no 404s or redirect loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)